### PR TITLE
Source nvm with --no-use

### DIFF
--- a/nvm.fish
+++ b/nvm.fish
@@ -90,7 +90,7 @@ function nvm-fast
 			set fish_user_paths $new_path
 		end
 	else
-		bash -c "source ~/.nvm/nvm.sh; nvm $argv"
+		bash -c "source ~/.nvm/nvm.sh --no-use; nvm $argv"
 	end
 end
 


### PR DESCRIPTION
This stops nvm stomping on the existing loaded path, and ensures `nvm current` is correct.

Fixes #9.