### PR TITLE
Print version on `use`

### DIFF
--- a/nvm.fish
+++ b/nvm.fish
@@ -26,7 +26,8 @@ function nvm-fast
 			end
 			set -g fish_user_paths $new_path
 
-			if not status --is-login
+			# Check if we're in startup
+			if not status --print-stack-trace | grep 'called during startup' >/dev/null
 				if test $matched_version = 'system'
 					echo "Now using system version of node:" (node -v 2>/dev/null)
 				else

--- a/nvm.fish
+++ b/nvm.fish
@@ -27,6 +27,12 @@ function nvm-fast
 				set new_path $brigand_nvm_fish_path/$matched_version/bin $new_path
 			end
 			set fish_user_paths $new_path
+
+			if test $matched_version = 'system'
+				echo "Now using system version of node:" (node -v 2>/dev/null)
+			else
+				echo "Now using node $matched_version"
+			end
 		end
 	else
 		bash -c "source ~/.nvm/nvm.sh; nvm $argv"

--- a/nvm.fish
+++ b/nvm.fish
@@ -26,10 +26,12 @@ function nvm-fast
 			end
 			set -g fish_user_paths $new_path
 
-			if test $matched_version = 'system'
-				echo "Now using system version of node:" (node -v 2>/dev/null)
-			else
-				echo "Now using node $matched_version"
+			if not status --is-login
+				if test $matched_version = 'system'
+					echo "Now using system version of node:" (node -v 2>/dev/null)
+				else
+					echo "Now using node $matched_version"
+				end
 			end
 		end
 	else


### PR DESCRIPTION
This outputs the version you've just switched to, which is handy when you've used an alias.

Native nvm also prints the npm version, I decided not to bother here just for brevity's sake, but it would only require adding `" (npm v" (npm --version 2>/dev/null) ")"` to it, after checking that `npm` exists.