### PR TITLE
Allow for custom NVM_DIR locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ To make it work on new shells you'll need to set a version in `config.fish`.
 ```sh
 echo 'nvm use 7.2.1' >> ~/.config/fish/config.fish
 ```
+
+If you have nvm installed anywhere other than ~/.nvm, set a global
+variable in your `config.fish` file *before* first invoking `nvm use`.
+
+```sh
+set -gx NVM_DIR ~/custom_path/nvm
+nvm use 7.2.1
+```

--- a/nvm.beta.fish
+++ b/nvm.beta.fish
@@ -1,5 +1,6 @@
 function brigand_nvm_fish_find_matching_version --description 'Finds the version matching the semver string'
-	set -l brigand_nvm_fish_path ~/.nvm/versions/node
+	set -q NVM_DIR ; or set -l NVM_DIR ~/.nvm
+	set -l brigand_nvm_fish_path $NVM_DIR/versions/node
 	set -l target $argv[1]
 	set -l best_match 0 0 0
 	set -l raw_target_parts (echo $target | tr '.' '\n')
@@ -62,7 +63,7 @@ function brigand_nvm_fish_find_matching_version --description 'Finds the version
 end
 
 function nvm-fast
-	set -l brigand_nvm_fish_path ~/.nvm/versions/node
+	set -l brigand_nvm_fish_path $NVM_DIR/versions/node
 	if test (count $argv[1]) -lt 1
 		echo 'nvm-fast: at least one argument is required'
 	end
@@ -90,7 +91,7 @@ function nvm-fast
 			set fish_user_paths $new_path
 		end
 	else
-		bash -c "source ~/.nvm/nvm.sh; nvm $argv"
+		bash -c "source $NVM_DIR/nvm.sh; nvm $argv"
 	end
 end
 

--- a/nvm.fish
+++ b/nvm.fish
@@ -1,5 +1,6 @@
 function nvm-fast
-	set -l brigand_nvm_fish_path ~/.nvm/versions/node
+	set -q NVM_DIR ; or set -l NVM_DIR ~/.nvm
+	set -l brigand_nvm_fish_path $NVM_DIR/versions/node
 	if test (count $argv[1]) -lt 1
 		echo 'nvm-fast: at least one argument is required'
 	end
@@ -7,7 +8,7 @@ function nvm-fast
 	set -l command $argv[1]
 	if test $command = 'use'
 		set -l target_version $argv[2]
-		set -l matched_version (bash -c "source ~/.nvm/nvm.sh --no-use; nvm_version $target_version")
+		set -l matched_version (bash -c "source $NVM_DIR/nvm.sh --no-use; nvm_version $target_version")
 		if test -z $matched_version -o $matched_version = 'N/A'
 			echo "No version installed for $target_version, run nvm install $target_version"
 			echo "Installed versions: "
@@ -27,7 +28,7 @@ function nvm-fast
 			set -g fish_user_paths $new_path
 		end
 	else
-		bash -c "source ~/.nvm/nvm.sh --no-use; nvm $argv"
+		bash -c "source $NVM_DIR/nvm.sh --no-use; nvm $argv"
 	end
 end
 


### PR DESCRIPTION
Nvm allows installing in [custom paths](https://github.com/creationix/nvm#manual-install), as long as the correct environment variable is set.

This pull request tweaks the functions so that it checks for `$NVM_DIR` first. If unset, it defaults to `~/.nvm`, else it uses the globally set value.