### PR TITLE
Enforce minimum required Fish version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ nvm use 5 # or e.g. 5.8 or 5.8.1
 
 ## Install:
 
+**Requirements:** you must have Fish 2.6.0 or newer.
+
 First install nvm if you haven't already. You can check the [nvm readme] for a more up to data install command.
 
 [nvm readme]: https://github.com/creationix/nvm/blob/master/README.md#install-script

--- a/nvm.fish
+++ b/nvm.fish
@@ -41,6 +41,11 @@ function nvm-fast
 end
 
 function nvm
+	switch "$FISH_VERSION"
+		case 2.0.0 2.1.0 2.1.1 2.1.2 2.2.0 2.2b1 2.3.0 2.3.1 2.3b1 2.3b2 2.4.0 2.4b1 2.5.0 2.5b1
+			echo "You need fish 2.6.0 or higher to use fast-nvm-fish." 1>&2
+			return 1
+	end
 	nvm-fast $argv
 end
 


### PR DESCRIPTION
This is a fix for https://github.com/brigand/fast-nvm-fish/issues/20.

Thanks for the useful script. Those slow shell startups were really getting to me.